### PR TITLE
Use Firebase service account auth in workflows

### DIFF
--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -49,8 +49,6 @@ jobs:
           sudo mv hugo-tools /usr/local/bin/hugo-tools
 
       - name: Update assets
-        env:
-          GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
         run: |
           npm install
           make assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,20 +58,23 @@ jobs:
 
       # - name: QA
       #   env:
-      #     FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      #     FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_QA }}
+      #     GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
       #     GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
       #   if: startsWith(github.event.ref, 'refs/tags/') && (contains(github.ref, '-alpha.') || contains(github.ref, '-beta.'))
       #   run: |
+      #     echo "$FIREBASE_SERVICE_ACCOUNT" > "$GOOGLE_APPLICATION_CREDENTIALS"
       #     npm install
       #     make assets
       #     make qa
 
       - name: Release
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          GOOGLE_CUSTOM_SEARCH_API_KEY: ${{ secrets.GOOGLE_CUSTOM_SEARCH_API_KEY }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_PROD }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/firebase-service-account.json
         # if: startsWith(github.event.ref, 'refs/tags/') && (contains(github.ref, '-alpha.') || contains(github.ref, '-beta.')) == false
         run: |
+          echo "$FIREBASE_SERVICE_ACCOUNT" > "$GOOGLE_APPLICATION_CREDENTIALS"
           npm install
           make assets
           make release


### PR DESCRIPTION
## Summary
- Replace deprecated `FIREBASE_TOKEN` with `FIREBASE_SERVICE_ACCOUNT_PROD` (release) / `FIREBASE_SERVICE_ACCOUNT_QA` (commented QA job)
- Write service account JSON to disk and point `GOOGLE_APPLICATION_CREDENTIALS` at it so firebase-tools picks it up
- Drop now-unused `GOOGLE_CUSTOM_SEARCH_API_KEY` env from preview-website and release workflows

## Test plan
- [ ] Confirm `FIREBASE_SERVICE_ACCOUNT_PROD` and `FIREBASE_SERVICE_ACCOUNT_QA` GitHub secrets contain valid service account JSON with Firebase Hosting roles
- [ ] Verify release workflow run deploys successfully to prod Firebase project

🤖 Generated with [Claude Code](https://claude.com/claude-code)